### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WooCommerce Digital Goods Checkout ===
 Contributors: claudiosanches
-Donate link: http://claudiosmweb.com/doacoes/
+Donate link: https://claudiosmweb.com/doacoes/
 Tags: woocommerce, digital goods, virtual products
 Requires at least: 4.0
-Tested up to: 4.7
-Stable tag: 1.0.0
+Tested up to: 5.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,7 +18,7 @@ Not required any kind of configuration, just install and activate this plugin :)
 
 = Compatibility =
 
-* [WooCommerce](https://wordpress.org/plugins/woocommerce/) 2.2 or later (yes, this includes support for 2.6).
+* [WooCommerce](https://wordpress.org/plugins/woocommerce/) 2.2 or later (yes, this includes support for 3.6).
 * [WooCommerce Extra Checkout Fields for Brazil](https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/) 3.4.2 or later.
 * [WooCommerce Pagar.me](https://wordpress.org/plugins/woocommerce-pagarme/) 1.2.3 or later.
 


### PR DESCRIPTION
I mentioned this plugin to a few folks & they got worried b/c they saw the _'This plugin hasn’t been tested........'_ warning was showing in the [.org repo](https://wordpress.org/plugins/wc-digital-goods-checkout/).  Hopefully these changes will allow 'ya to push this into the WP repo plugin as well & make that notification go away 👍 

![image](https://user-images.githubusercontent.com/6208757/48385326-a9605f80-e6b3-11e8-85d1-7cbf28a2626e.png)

#### Obrigado por todo o trabalho duro
